### PR TITLE
feat: implement product status update functionality

### DIFF
--- a/src/app/products/controller/products.controller.spec.ts
+++ b/src/app/products/controller/products.controller.spec.ts
@@ -2,16 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ProductsController } from './products.controller';
 import { ProductsService } from '../services/products.service';
 import { SearchQueryParamsDto } from '../dto/product.dto';
+import { IUpdateResult } from '../interface/producto.interface';
 
 describe('ProductsController (unit)', () => {
   let controller: ProductsController;
   let service: {
     findAll: jest.Mock;
+    updateStatus: jest.Mock;
   };
 
   beforeEach(async () => {
     service = {
       findAll: jest.fn(),
+      updateStatus: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -67,5 +70,26 @@ describe('ProductsController (unit)', () => {
       expect(service.findAll).toHaveBeenCalledWith(query);
       expect(res).toEqual(expected);
     });
+  });
+
+  describe('/PATCH products/:id/status', () => {
+    it('should call service to update product status and return the result', async () => {
+      const productId = '123e4567-e89b-12d3-a456-426614174000';
+      const expectedResult: IUpdateResult = {
+        generatedMaps: [],
+        affected: 1,
+        raw: {},
+      };
+      service.updateStatus.mockResolvedValue(expectedResult);
+
+      const res = await controller.updateStatus(productId);
+
+      expect(service.updateStatus).toHaveBeenCalledWith(productId);
+      expect(res).toEqual(expectedResult);
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 });

--- a/src/app/products/controller/products.controller.ts
+++ b/src/app/products/controller/products.controller.ts
@@ -1,8 +1,16 @@
-import { Controller, Get, Body, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Query,
+} from '@nestjs/common';
 import { ProductsService } from '../services/products.service';
 import { ApiTags } from '@nestjs/swagger';
 import { SearchQueryParamsDto } from '../dto/product.dto';
 import { IResultData, IProduct } from '../interface/producto.interface';
+import { IUpdateResult } from '../interface/producto.interface';
 
 @ApiTags('Products')
 @Controller('products')
@@ -14,5 +22,12 @@ export class ProductsController {
     @Query() filter: SearchQueryParamsDto,
   ): Promise<IResultData<IProduct>> {
     return this.productsService.findAll(filter);
+  }
+
+  @Patch('status/:id')
+  async updateStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<IUpdateResult> {
+    return await this.productsService.updateStatus(id);
   }
 }

--- a/src/app/products/interface/producto.interface.ts
+++ b/src/app/products/interface/producto.interface.ts
@@ -1,3 +1,4 @@
+import { ObjectLiteral } from 'typeorm';
 import { PaginatedResult } from '../../../shared/dto/paginated-result.dto';
 
 export interface IProduct {
@@ -18,4 +19,9 @@ export interface IProduct {
   deletedAt?: Date | null;
 }
 
+export interface IUpdateResult {
+  generatedMaps: ObjectLiteral[];
+  raw: any;
+  affected?: number;
+}
 export type IResultData<T = IProduct> = PaginatedResult<T>;

--- a/src/app/products/repositories/products.repository.ts
+++ b/src/app/products/repositories/products.repository.ts
@@ -13,6 +13,7 @@ import {
 //
 import { Products } from '../entities/product.entity';
 import { CategoryReportResult } from '../../reports/interface/reports.interface';
+import { IUpdateResult } from '../interface/producto.interface';
 import { SearchQueryParamsDto } from '../dto/product.dto';
 import { ReportsQueryParamsDto } from '../../reports/dto/reports.dto';
 import { createDateRange } from '../../../utils/date';
@@ -128,10 +129,25 @@ export class ProductsRepository {
       .getRawMany();
   }
 
+  async findOne(id: string): Promise<Partial<Products> | null> {
+    return this.productsRepository.findOne({
+      where: {
+        id,
+      },
+      withDeleted: true,
+    });
+  }
+
   async productUpsert(product: Partial<Products>) {
     const result = await this.productsRepository.upsert(product, [
       'externalId',
     ]);
+    return result;
+  }
+  async updateStatus(id: string): Promise<IUpdateResult> {
+    const result = await this.productsRepository.update(id, {
+      isDeleted: true,
+    });
     return result;
   }
 }

--- a/src/app/products/services/products.service.spec.ts
+++ b/src/app/products/services/products.service.spec.ts
@@ -6,6 +6,7 @@ import { Products } from '../entities/product.entity';
 import { SearchQueryParamsDto } from '../dto/product.dto';
 import { InsertResult } from 'typeorm';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { IUpdateResult } from '../interface/producto.interface';
 
 describe('ProductsService (unit)', () => {
   let service: ProductsService;
@@ -16,6 +17,8 @@ describe('ProductsService (unit)', () => {
     const repoMock: Partial<jest.Mocked<ProductsRepository>> = {
       findAll: jest.fn(),
       productUpsert: jest.fn(),
+      updateStatus: jest.fn(),
+      findOne: jest.fn(),
     };
 
     const contenfulServiceMock: Partial<jest.Mocked<ContenfulService>> = {
@@ -184,6 +187,43 @@ describe('ProductsService (unit)', () => {
       );
       // Verify the result
       expect(result).toEqual(mockUpsertResults);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update product status successfully', async () => {
+      const productId = '123e4567-e89b-12d3-a456-426614174000';
+      const mockProduct = {
+        id: productId,
+        externalId: 'EXT1',
+        sku: 'SKU1',
+        name: 'Test Product',
+        brand: 'Brand',
+        model: 'Model X',
+        category: 'Cat',
+        color: 'Red',
+        price: 100,
+        currency: 'USD',
+        stock: 10,
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: undefined,
+      };
+      const mockUpdateResult: IUpdateResult = {
+        generatedMaps: [],
+        affected: 1,
+        raw: {},
+      };
+
+      repo.findOne.mockResolvedValue(mockProduct);
+      repo.updateStatus.mockResolvedValue(mockUpdateResult);
+
+      const result = await service.updateStatus(productId);
+
+      expect(jest.spyOn(repo, 'findOne')).toHaveBeenCalledWith(productId);
+      expect(jest.spyOn(repo, 'updateStatus')).toHaveBeenCalledWith(productId);
+      expect(result).toEqual(mockUpdateResult);
     });
   });
   //

--- a/src/app/products/services/products.service.ts
+++ b/src/app/products/services/products.service.ts
@@ -8,6 +8,7 @@ import { paginateResult } from '../../../shared/utils/pagination.util';
 import { IResultData, IProduct } from '../interface/producto.interface';
 import { createContextWinston } from '../../../utils/logger.util';
 import { ContenfulService } from './contenful.service';
+import { IUpdateResult } from '../interface/producto.interface';
 
 @Injectable()
 export class ProductsService {
@@ -43,5 +44,26 @@ export class ProductsService {
     this.logger.log('Fetching all products', { context, filter });
     const { results, count } = await this.productsRepository.findAll(filter);
     return paginateResult<IProduct>(count, results, filter.limit, filter.page);
+  }
+
+  async updateStatus(id: string): Promise<IUpdateResult> {
+    const context = createContextWinston(
+      this.constructor.name,
+      this.updateStatus.name,
+    );
+    // find the product first
+    this.logger.log('Updating product status', { context, id });
+    const product = await this.productsRepository.findOne(id);
+    if (!product) {
+      this.logger.warn('Product not found', { context, id });
+      throw new Error('Product not found');
+    }
+    // Check if the product is already deleted
+    if (product.isDeleted) {
+      this.logger.warn('Product is already deleted', { context, id });
+      throw new Error('Product is already deleted');
+    }
+    //
+    return await this.productsRepository.updateStatus(id);
   }
 }


### PR DESCRIPTION
##  What does this PR do?
Adds functionality to soft delete products through a PATCH endpoint.

## Description

- New endpoint: PATCH  to update product's  status to true
- Validations: Verifies product exists and isn't already deleted before updating
- Tests: Adds unit tests for controller and service for the new endpoint
- Logging: Includes logs for tracking delete operations

This implementation allows "deleting" products without physically removing them from the database, maintaining referential integrity.
